### PR TITLE
Implement add-income and balance commands to close #14

### DIFF
--- a/src/main/java/seedu/fintrack/FinTrack.java
+++ b/src/main/java/seedu/fintrack/FinTrack.java
@@ -2,17 +2,38 @@ package seedu.fintrack;
 
 public class FinTrack {
     /**
-     * Main entry-point for the java.finTrack.FinTrack application.
+     * Main entry-point for the FinTrack application.
      */
     public static void main(String[] args) {
         Ui.printWelcome();
+        FinanceManager fm = new FinanceManager();
+
         while (true) {
             String input = Ui.waitForInput();
             if (input.equals(Ui.getExitCommand())) {
                 break;
             }
-            System.out.println("You entered: " + input);
+
+            if (input.startsWith(Ui.getAddIncomeCommand())) {
+                try {
+                    var income = Parser.parseAddIncome(input);
+                    fm.addIncome(income);
+                    Ui.printIncomeAdded(income);
+                } catch (IllegalArgumentException e) {
+                    Ui.printError(e.getMessage());
+                }
+                continue;
+            }
+
+            if (input.equals(Ui.getBalanceCommand())) {
+                double balance = fm.getBalance();
+                Ui.printBalance(balance, fm.getTotalIncome(), fm.getTotalExpense());
+                continue;
+            }
+
+            Ui.printError("Unknown command.");
         }
+
         Ui.printExit();
     }
 }

--- a/src/main/java/seedu/fintrack/FinTrack.java
+++ b/src/main/java/seedu/fintrack/FinTrack.java
@@ -1,5 +1,15 @@
 package seedu.fintrack;
-
+/**
+ * Entry point of the FinTrack application.
+ * <p>
+ * Handles the main CLI loop for receiving and processing user commands.
+ * Supports:
+ * <ul>
+ *   <li><code>add-income</code>: Adds a new income entry.</li>
+ *   <li><code>balance</code>: Displays overall balance (total income minus total expense).</li>
+ *   <li><code>bye</code>: Exits the program.</li>
+ * </ul>
+ */
 public class FinTrack {
     /**
      * Main entry-point for the FinTrack application.

--- a/src/main/java/seedu/fintrack/FinanceManager.java
+++ b/src/main/java/seedu/fintrack/FinanceManager.java
@@ -1,0 +1,31 @@
+package seedu.fintrack;
+
+import java.util.ArrayList;
+import java.util.List;
+import seedu.fintrack.model.Income;
+import seedu.fintrack.model.Expense;
+
+public class FinanceManager {
+    private final List<Income> incomes = new ArrayList<>();
+    private final List<Expense> expenses = new ArrayList<>(); // kept for balance math; not adding features
+
+    public void addIncome(Income income) {
+        if (income == null) {
+            throw new IllegalArgumentException("Income cannot be null");
+        }
+        incomes.add(income);
+    }
+
+    public double getTotalIncome() {
+        return incomes.stream().mapToDouble(Income::getAmount).sum();
+    }
+
+    public double getTotalExpense() {
+        return expenses.stream().mapToDouble(Expense::getAmount).sum();
+    }
+
+    /** View Overall Balance (income - expense). */
+    public double getBalance() {
+        return getTotalIncome() - getTotalExpense();
+    }
+}

--- a/src/main/java/seedu/fintrack/Parser.java
+++ b/src/main/java/seedu/fintrack/Parser.java
@@ -1,0 +1,82 @@
+package seedu.fintrack;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import seedu.fintrack.model.Income;
+
+final class Parser {
+    private Parser() {}
+
+    /**
+     * Expected format:
+     * add-income a/<amount> c/<category> d/<YYYY-MM-DD> [desc/<text>]
+     */
+    static Income parseAddIncome(String input) {
+        String cmd = Ui.getAddIncomeCommand();
+        if (!input.startsWith(cmd)) {
+            throw new IllegalArgumentException("Invalid command. Use 'help' to see usage.");
+        }
+        String args = input.substring(cmd.length()).trim();
+        if (args.isEmpty()) {
+            throw new IllegalArgumentException("Missing parameters. See 'help'.");
+        }
+
+        String amountStr = getValue(args, Ui.getAmountPrefix());
+        String category = getValue(args, Ui.getCategoryPrefix());
+        String dateStr = getValue(args, Ui.getDatePrefix());
+        String description = getOptionalValue(args, Ui.getDescriptionPrefix());
+
+        if (amountStr == null || category == null || dateStr == null) {
+            throw new IllegalArgumentException("Required fields: a/<amount> c/<category> d/<YYYY-MM-DD>.");
+        }
+
+        double amount;
+        try {
+            amount = Double.parseDouble(amountStr);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Amount must be a valid number.");
+        }
+        if (amount < 0) {
+            throw new IllegalArgumentException("Amount must be non-negative.");
+        }
+
+        LocalDate date;
+        try {
+            date = LocalDate.parse(dateStr);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("Date must be in YYYY-MM-DD format.");
+        }
+
+        return new Income(amount, category, date, description);
+    }
+
+    private static String getValue(String args, String prefix) {
+        int start = args.indexOf(prefix);
+        if (start < 0) return null;
+        start += prefix.length();
+
+        // Find the next prefix or end-of-string
+        int next = findNextPrefixIndex(args, start);
+        String val = (next < 0) ? args.substring(start) : args.substring(start, next);
+        return val.trim().isEmpty() ? null : val.trim();
+    }
+
+    private static String getOptionalValue(String args, String prefix) {
+        String v = getValue(args, prefix);
+        return v == null ? "" : v;
+    }
+
+    private static int findNextPrefixIndex(String args, int fromIndex) {
+        int next = -1;
+        String[] prefixes = {
+                Ui.getAmountPrefix(), Ui.getCategoryPrefix(), Ui.getDatePrefix(), Ui.getDescriptionPrefix()
+        };
+        for (String p : prefixes) {
+            int idx = args.indexOf(p, fromIndex);
+            if (idx >= 0 && (next < 0 || idx < next)) {
+                next = idx;
+            }
+        }
+        return next;
+    }
+}

--- a/src/main/java/seedu/fintrack/Parser.java
+++ b/src/main/java/seedu/fintrack/Parser.java
@@ -9,7 +9,7 @@ final class Parser {
 
     /**
      * Expected format:
-     * add-income a/<amount> c/<category> d/<YYYY-MM-DD> [desc/<text>]
+     * {@code add-income a/<amount> c/<category> d/<YYYY-MM-DD> [desc/<text>]}
      */
     static Income parseAddIncome(String input) {
         String cmd = Ui.getAddIncomeCommand();
@@ -52,7 +52,9 @@ final class Parser {
 
     private static String getValue(String args, String prefix) {
         int start = args.indexOf(prefix);
-        if (start < 0) return null;
+        if (start < 0) {
+            return null;
+        }
         start += prefix.length();
 
         // Find the next prefix or end-of-string

--- a/src/main/java/seedu/fintrack/Ui.java
+++ b/src/main/java/seedu/fintrack/Ui.java
@@ -37,7 +37,7 @@ public class Ui {
 
     /** Prints the exit message. */
     public static void printExit() {
-        System.out.println("Bye. Hope to see you again soon!");
+        System.out.print("Bye. Hope to see you again soon!");
     }
 
     static String getAddIncomeCommand() { return ADD_INCOME_COMMAND; }

--- a/src/main/java/seedu/fintrack/Ui.java
+++ b/src/main/java/seedu/fintrack/Ui.java
@@ -1,55 +1,65 @@
 package seedu.fintrack;
 
 import java.util.Scanner;
+import seedu.fintrack.model.Income;
 
 public class Ui {
-    // Commands (class/static variables)
-    private static final String HELP_COMMAND = "help";
-    private static final String ADD_EXPENSE_COMMAND = "add-expense";
+    // Commands
     private static final String ADD_INCOME_COMMAND = "add-income";
-    private static final String DELETE_COMMAND = "delete";
     private static final String BALANCE_COMMAND = "balance";
-    private static final String LIST_COMMAND = "list";
     private static final String EXIT_COMMAND = "bye";
 
     // Parameter prefixes
     private static final String AMOUNT_PREFIX = "a/";
     private static final String CATEGORY_PREFIX = "c/";
     private static final String DATE_PREFIX = "d/";
+    private static final String DESCRIPTION_PREFIX = "desc/"; // optional
 
     private static final Scanner SCANNER = new Scanner(System.in);
 
     public static void printWelcome() {
         System.out.println("Welcome to FinTrack!");
-        System.out.println("Type '" + HELP_COMMAND + "' for available commands.");
         System.out.println();
     }
 
-    /**
-     * Waits for a single line of user input and returns it.
-     * Prints a simple > for formatting before waiting.
-     */
+    /** Waits for a single line of user input and returns it. */
     public static String waitForInput() {
         System.out.print("> ");
-        return SCANNER.nextLine();
+        return SCANNER.nextLine().trim();
     }
 
-    /**
-     * Prints the exit message.
-     */
+    /** Prints the exit message. */
     public static void printExit() {
         System.out.println("Bye. Hope to see you again soon!");
     }
 
-    static String getHelpCommand() { return HELP_COMMAND; }
-    static String getAddExpenseCommand() { return ADD_EXPENSE_COMMAND; }
     static String getAddIncomeCommand() { return ADD_INCOME_COMMAND; }
-    static String getDeleteCommand() { return DELETE_COMMAND; }
     static String getBalanceCommand() { return BALANCE_COMMAND; }
-    static String getListCommand() { return LIST_COMMAND; }
+    static String getExitCommand() { return EXIT_COMMAND; }
 
     static String getAmountPrefix() { return AMOUNT_PREFIX; }
     static String getCategoryPrefix() { return CATEGORY_PREFIX; }
     static String getDatePrefix() { return DATE_PREFIX; }
-    static String getExitCommand() { return EXIT_COMMAND; }
+    static String getDescriptionPrefix() { return DESCRIPTION_PREFIX; }
+
+    // Output formatting
+    static void printIncomeAdded(Income income) {
+        System.out.println("Income added:");
+        System.out.println("  Amount: " + String.format("%.2f", income.getAmount()));
+        System.out.println("  Category: " + income.getCategory());
+        System.out.println("  Date: " + income.getDate());
+        if (income.getDescription() != null && !income.getDescription().isBlank()) {
+            System.out.println("  Description: " + income.getDescription());
+        }
+    }
+
+    static void printBalance(double balance, double totalIncome, double totalExpense) {
+        System.out.println("Overall Balance: " + String.format("%.2f", balance));
+        System.out.println("  Total Income:  " + String.format("%.2f", totalIncome));
+        System.out.println("  Total Expense: " + String.format("%.2f", totalExpense));
+    }
+
+    static void printError(String message) {
+        System.out.println("Error: " + message);
+    }
 }

--- a/src/main/java/seedu/fintrack/Ui.java
+++ b/src/main/java/seedu/fintrack/Ui.java
@@ -25,6 +25,7 @@ public class Ui {
 
     public static void printWelcome() {
         System.out.println("Welcome to FinTrack!");
+        System.out.println("Type 'help' for available commands.");
         System.out.println();
     }
 

--- a/src/main/java/seedu/fintrack/Ui.java
+++ b/src/main/java/seedu/fintrack/Ui.java
@@ -1,13 +1,14 @@
 package seedu.fintrack;
+
+import java.util.Scanner;
+import seedu.fintrack.model.Income;
+
 /**
  * Handles all user interaction for FinTrack.
  * <p>
  * Provides methods for displaying messages, reading input, and formatting output
  * for features such as adding income and viewing the overall balance.
  */
-import java.util.Scanner;
-import seedu.fintrack.model.Income;
-
 public class Ui {
     // Commands
     private static final String ADD_INCOME_COMMAND = "add-income";

--- a/src/main/java/seedu/fintrack/Ui.java
+++ b/src/main/java/seedu/fintrack/Ui.java
@@ -1,5 +1,10 @@
 package seedu.fintrack;
-
+/**
+ * Handles all user interaction for FinTrack.
+ * <p>
+ * Provides methods for displaying messages, reading input, and formatting output
+ * for features such as adding income and viewing the overall balance.
+ */
 import java.util.Scanner;
 import seedu.fintrack.model.Income;
 

--- a/src/main/java/seedu/fintrack/model/Expense.java
+++ b/src/main/java/seedu/fintrack/model/Expense.java
@@ -1,0 +1,11 @@
+package seedu.fintrack.model;
+
+public class Expense {
+    private final double amount;
+
+    public Expense(double amount) {
+        this.amount = amount;
+    }
+
+    public double getAmount() { return amount; }
+}

--- a/src/main/java/seedu/fintrack/model/Income.java
+++ b/src/main/java/seedu/fintrack/model/Income.java
@@ -1,0 +1,22 @@
+package seedu.fintrack.model;
+
+import java.time.LocalDate;
+
+public class Income {
+    private final double amount;
+    private final String category;
+    private final LocalDate date;
+    private final String description; // optional
+
+    public Income(double amount, String category, LocalDate date, String description) {
+        this.amount = amount;
+        this.category = category;
+        this.date = date;
+        this.description = (description == null || description.isBlank()) ? null : description;
+    }
+
+    public double getAmount() { return amount; }
+    public String getCategory() { return category; }
+    public LocalDate getDate() { return date; }
+    public String getDescription() { return description; }
+}

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -1,4 +1,5 @@
 Welcome to FinTrack!
+Type 'help' for available commands.
 
 > Error: Unknown command.
 > Bye. Hope to see you again soon!

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -1,5 +1,4 @@
 Welcome to FinTrack!
-Type 'help' for available commands.
 
-> You entered: James Gosling
+> Error: Unknown command.
 > Bye. Hope to see you again soon!


### PR DESCRIPTION
- Added `add-income` command to log income entries with amount, category, date, and optional description.
- Added `balance` command to display overall balance (total income - total expense).
- Introduced `FinanceManager`, `Income`, and minimal `Expense` classes for in-memory tracking.
- Implemented `Parser` for argument extraction and validation.
- Updated `Ui` and `FinTrack` for new CLI interactions.