### PR TITLE
Enable income listing via new list-income command

### DIFF
--- a/src/main/java/seedu/fintrack/FinTrack.java
+++ b/src/main/java/seedu/fintrack/FinTrack.java
@@ -96,6 +96,9 @@ public class FinTrack {
             case Ui.LIST_COMMAND:
                 Ui.printListOfExpenses(fm.getExpensesView());
                 break;
+            case Ui.LIST_INCOME_COMMAND:
+                Ui.printListOfIncomes(fm.getIncomesView());
+                break;
             case Ui.HELP_COMMAND:
                 Ui.printHelp();
                 break;

--- a/src/main/java/seedu/fintrack/FinanceManager.java
+++ b/src/main/java/seedu/fintrack/FinanceManager.java
@@ -1,6 +1,7 @@
 package seedu.fintrack;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.logging.Level;
@@ -65,6 +66,13 @@ public class FinanceManager {
         assert !Double.isNaN(totalIncome) : "Total income should be a number.";
         assert !Double.isNaN(totalExpense) : "Total expense should be a number.";
         return totalIncome - totalExpense;
+    }
+
+    /** Returns an unmodifiable view of incomes in the order they were added. */
+    public List<Income> getIncomesView() {
+        List<Income> incomeList = Collections.unmodifiableList(incomes);
+        assert incomeList != null : "Income list should not be null.";
+        return incomeList;
     }
 
     /** Returns an unmodifiable newest-first view for printing. */

--- a/src/test/java/seedu/fintrack/FinanceManagerTest.java
+++ b/src/test/java/seedu/fintrack/FinanceManagerTest.java
@@ -80,6 +80,24 @@ public class FinanceManagerTest {
         fm.addIncome(sampleIncome2); // 200
         assertEquals(5200.0, fm.getTotalIncome());
     }
+
+    @Test
+    void getIncomesView_noIncomes_returnsEmptyList() {
+        List<Income> incomes = fm.getIncomesView();
+        assertTrue(incomes.isEmpty());
+    }
+
+    @Test
+    void getIncomesView_withIncomes_returnsUnmodifiableOldestFirstView() {
+        fm.addIncome(sampleIncome1);
+        fm.addIncome(sampleIncome2);
+
+        List<Income> incomes = fm.getIncomesView();
+        assertEquals(2, incomes.size());
+        assertEquals(sampleIncome1, incomes.get(0)); // oldest first
+        assertEquals(sampleIncome2, incomes.get(1));
+        assertThrows(UnsupportedOperationException.class, () -> incomes.add(sampleIncome1));
+    }
     
     @Test
     void getTotalExpense_noExpenses_returnsZero() {

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -47,6 +47,19 @@ Amount: $1200.00
 Category: Rent
 Description: Monthly rent payment
 --------------------------------------------------
+> Incomes (Oldest first):
+--------------------------------------------------
+#1
+Date: 2024-01-01
+Amount: $5000.00
+Category: Salary
+Description: Monthly salary
+--------------------------------------------------
+#2
+Date: 2024-01-15
+Amount: $200.00
+Category: Freelance
+--------------------------------------------------
 > Expense deleted (index 2):
   Amount: 50.00
   Category: Food
@@ -72,23 +85,26 @@ Description: Monthly rent payment
 3. View all expenses (from latest to earliest date):
    list
 
-4. Delete an expense:
+4. View all incomes (in the order they were added):
+   list-income
+
+5. Delete an expense:
    delete-expense <index>
    Deletes the expense shown at that index in 'list'.
    Example: delete-expense 1
 
-5. Delete an income:
+6. Delete an income:
    delete-income <index>
    Example: delete-income 1
 
-6. View balance summary:
+7. View balance summary:
    balance
    Shows total income, total expenses, and current balance.
 
-7. Show this help menu:
+8. Show this help menu:
    help
 
-8. Exit the program:
+9. Exit the program:
    bye
 --------------------------------------------------------------------------------
 > Bye. Hope to see you again soon!

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -6,6 +6,7 @@ add-expense a/50 c/Food d/2024-01-02
 add-expense a/30 c/Transport d/2024-01-03 desc/Bus fare
 balance
 list
+list-income
 delete-expense 2
 delete-income 1
 balance


### PR DESCRIPTION
  - introduce a list-income CLI command that surfaces all recorded incomes in the order they were  
    added                                                                                          
  - expose an unmodifiable income view from FinanceManager and add a UI renderer mirroring the     
    expense list                                                                                   
  - expand automated coverage and text UI scripts to exercise the new listing behaviour                                                                  
                                                                                                   
  Closes #56.