### PR TITLE
Rename expense listing command and require d/ month prefix

### DIFF
--- a/src/main/java/seedu/fintrack/FinTrack.java
+++ b/src/main/java/seedu/fintrack/FinTrack.java
@@ -170,7 +170,7 @@ public class FinTrack {
                     Ui.printError(e.getMessage());
                 }
                 break;
-            case Ui.LIST_COMMAND:
+            case Ui.LIST_EXPENSE_COMMAND:
                 try {
                     Optional<YearMonth> ymOpt = Parser.parseOptionalMonthForExpenseList(input);
                     if (ymOpt.isPresent()) {

--- a/src/main/java/seedu/fintrack/Parser.java
+++ b/src/main/java/seedu/fintrack/Parser.java
@@ -390,23 +390,32 @@ final class Parser {
             LOGGER.log(Level.FINE, "No month argument detected for {0}", commandLiteral);
             return Optional.empty();
         }
-        
-        // Disallow extra tokens after the month (enforce exactly one arg if present)
-        int sp = rest.indexOf(' ');
-        if (sp != -1) {
+
+        if (!rest.startsWith(Ui.DATE_PREFIX)) {
+            LOGGER.log(Level.WARNING, "Missing d/ prefix for month after {0}: {1}",
+                    new Object[]{commandLiteral, rest});
+            throw new IllegalArgumentException("Usage: " + commandLiteral + " [" + Ui.DATE_PREFIX + "YYYY-MM]");
+        }
+
+        String monthToken = rest.substring(Ui.DATE_PREFIX.length()).trim();
+        if (monthToken.isEmpty()) {
+            LOGGER.log(Level.WARNING, "Month missing after d/ for command {0}", commandLiteral);
+            throw new IllegalArgumentException("Month must follow d/ in YYYY-MM format.");
+        }
+        if (monthToken.contains(" ")) {
             LOGGER.log(Level.WARNING, "Unexpected extra arguments after {0}: {1}",
                     new Object[]{commandLiteral, rest});
-            throw new IllegalArgumentException("Usage: " + commandLiteral + " [YYYY-MM]");
+            throw new IllegalArgumentException("Usage: " + commandLiteral + " [" + Ui.DATE_PREFIX + "YYYY-MM]");
         }
 
         try {
-            YearMonth parsed = YearMonth.parse(rest, YEAR_MONTH_FORMATTER);
+            YearMonth parsed = YearMonth.parse(monthToken, YEAR_MONTH_FORMATTER);
             LOGGER.log(Level.FINE, "Parsed YearMonth {0} for command {1}",
                     new Object[]{parsed, commandLiteral});
             return Optional.of(parsed);
         } catch (DateTimeParseException ex) {
             LOGGER.log(Level.WARNING, "Invalid month format after {0}: {1}",
-                    new Object[]{commandLiteral, rest});
+                    new Object[]{commandLiteral, monthToken});
             throw new IllegalArgumentException("Month must be in YYYY-MM format.");
         }
     }
@@ -418,7 +427,7 @@ final class Parser {
 
     public static Optional<YearMonth> parseOptionalMonthForExpenseList(String input) {
         LOGGER.fine("Entered parseOptionalMonthForExpenseList");
-        return parseOptionalYearMonthAfterCommand(input, Ui.LIST_COMMAND);
+        return parseOptionalYearMonthAfterCommand(input, Ui.LIST_EXPENSE_COMMAND);
     }
 
     public static Optional<YearMonth> parseOptionalMonthForIncomeList(String input) {

--- a/src/main/java/seedu/fintrack/Ui.java
+++ b/src/main/java/seedu/fintrack/Ui.java
@@ -27,7 +27,7 @@ public class Ui {
     public static final String BALANCE_COMMAND = "balance";
     public static final String BUDGET_COMMAND = "budget";
     public static final String LIST_BUDGET_COMMAND = "list-budget";
-    public static final String LIST_COMMAND = "list";
+    public static final String LIST_EXPENSE_COMMAND = "list-expense";
     public static final String LIST_INCOME_COMMAND = "list-income";
     public static final String MODIFY_EXPENSE_COMMAND = "modify-expense";
     public static final String MODIFY_INCOME_COMMAND = "modify-income";
@@ -482,26 +482,26 @@ public class Ui {
 
         System.out.println();
         System.out.println("3. View all expenses (from latest to earliest date):");
-        System.out.println("   " + LIST_COMMAND);
-        System.out.println("   To view by month: " + LIST_COMMAND + " <YYYY-MM>");
-        System.out.println("   Example: list 2025-10");
+        System.out.println("   " + LIST_EXPENSE_COMMAND);
+        System.out.println("   To view by month: " + LIST_EXPENSE_COMMAND + " d/<YYYY-MM>");
+        System.out.println("   Example: list-expense d/2025-10");
 
         System.out.println();
         System.out.println("4. View all incomes (from latest to earliest date):");
         System.out.println("   " + LIST_INCOME_COMMAND);
-        System.out.println("   To view by month: " + LIST_INCOME_COMMAND + " <YYYY-MM>");
-        System.out.println("   Example: list-income 2025-10");
+        System.out.println("   To view by month: " + LIST_INCOME_COMMAND + " d/<YYYY-MM>");
+        System.out.println("   Example: list-income d/2025-10");
 
         System.out.println();
         System.out.println("5. Delete an expense:");
         System.out.println("   " + DELETE_EXPENSE_COMMAND + " <index>");
-        System.out.println("   Deletes the expense shown at that index in 'list'.");
+        System.out.println("   Deletes the expense shown at that index in 'list-expense'.");
         System.out.println("   Example: delete-expense 1");
 
         System.out.println();
         System.out.println("6. Delete an income:");
         System.out.println("   " + DELETE_INCOME_COMMAND + " <index>");
-        System.out.println("   Deletes the income shown at that index in 'list'.");
+        System.out.println("   Deletes the income shown at that index in 'list-income'.");
         System.out.println("   Example: delete-income 1");
 
         System.out.println();
@@ -509,7 +509,7 @@ public class Ui {
         System.out.println("   "
                 + MODIFY_EXPENSE_COMMAND
                 + " <index> a/<amount> c/<category> d/<YYYY-MM-DD> [desc/<description>]");
-        System.out.println("   Modifies the expense shown at that index in 'list'.");
+        System.out.println("   Modifies the expense shown at that index in 'list-expense'.");
         System.out.println("   Example: modify-expense 1 a/1300 c/Rent d/2024-01-01 desc/Monthly rent increased");
 
         System.out.println();
@@ -524,8 +524,8 @@ public class Ui {
         System.out.println("9. View balance summary:");
         System.out.println("   " + BALANCE_COMMAND);
         System.out.println("   Shows total income, total expenses, and current balance.");
-        System.out.println("   To view by month: " + BALANCE_COMMAND + " <YYYY-MM>");
-        System.out.println("   Example: balance 2025-10");
+        System.out.println("   To view by month: " + BALANCE_COMMAND + " d/<YYYY-MM>");
+        System.out.println("   Example: balance d/2025-10");
 
         System.out.println();
         System.out.println("10. Set budget for expense categories:");

--- a/src/test/java/seedu/fintrack/ParserTest.java
+++ b/src/test/java/seedu/fintrack/ParserTest.java
@@ -674,7 +674,7 @@ public class ParserTest {
      */
 
     /**
-     * balance / balance YYYY-MM:
+     * balance / balance d/YYYY-MM:
      * - empty arg -> Optional.empty()
      * - valid month -> parsed YearMonth
      * - invalid month -> IllegalArgumentException
@@ -690,13 +690,21 @@ public class ParserTest {
         assertTrue(empty2.isEmpty());
 
         // Valid month
-        Optional<YearMonth> ok = Parser.parseOptionalMonthForBalance(Ui.BALANCE_COMMAND + " 2025-10");
+        Optional<YearMonth> ok = Parser.parseOptionalMonthForBalance(Ui.BALANCE_COMMAND + " d/2025-10");
         assertEquals(YearMonth.of(2025, 10), ok.get());
 
+        // Missing prefix
+        try {
+            Parser.parseOptionalMonthForBalance(Ui.BALANCE_COMMAND + " 2025-10");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Usage: balance [d/YYYY-MM]", e.getMessage());
+        }
+
         // Invalid month formats
-        String[] bads = {Ui.BALANCE_COMMAND + " 25-10", "empty", "empty"};
-        bads[1] = Ui.BALANCE_COMMAND + " 2025/10";
-        bads[2] = Ui.BALANCE_COMMAND + " 202510";
+        String[] bads = {Ui.BALANCE_COMMAND + " d/25-10", "empty", "empty"};
+        bads[1] = Ui.BALANCE_COMMAND + " d/2025/10";
+        bads[2] = Ui.BALANCE_COMMAND + " d/202510";
         for (String bad : bads) {
             try {
                 Parser.parseOptionalMonthForBalance(bad);
@@ -708,34 +716,43 @@ public class ParserTest {
     }
 
     /**
-     * list / list YYYY-MM:
+     * list-expense / list-expense d/YYYY-MM:
      * - valid, invalid, trimming
      */
     @Test
     public void parseOptionalMonthForExpenseList_cases() {
         // Valid
-        Optional<YearMonth> ok = Parser.parseOptionalMonthForExpenseList(Ui.LIST_COMMAND + " 2024-01");
+        Optional<YearMonth> ok = Parser.parseOptionalMonthForExpenseList(Ui.LIST_EXPENSE_COMMAND + " d/2024-01");
         assertEquals(YearMonth.of(2024, 1), ok.get());
 
         // Leading/trailing spaces
-        Optional<YearMonth> okSp = Parser.parseOptionalMonthForExpenseList(Ui.LIST_COMMAND + "   2024-12   ");
+        Optional<YearMonth> okSp = Parser.parseOptionalMonthForExpenseList(
+                Ui.LIST_EXPENSE_COMMAND + "   d/ 2024-12   ");
         assertEquals(YearMonth.of(2024, 12), okSp.get());
 
         // Empty -> Optional.empty()
-        Optional<YearMonth> none = Parser.parseOptionalMonthForExpenseList(Ui.LIST_COMMAND);
+        Optional<YearMonth> none = Parser.parseOptionalMonthForExpenseList(Ui.LIST_EXPENSE_COMMAND);
         assertTrue(none.isEmpty());
 
         // Invalid format
         try {
-            Parser.parseOptionalMonthForExpenseList(Ui.LIST_COMMAND + " 2024/01");
+            Parser.parseOptionalMonthForExpenseList(Ui.LIST_EXPENSE_COMMAND + " d/2024/01");
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("Month must be in YYYY-MM format.", e.getMessage());
         }
+
+        // Missing prefix
+        try {
+            Parser.parseOptionalMonthForExpenseList(Ui.LIST_EXPENSE_COMMAND + " 2024-01");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Usage: list-expense [d/YYYY-MM]", e.getMessage());
+        }
     }
 
     /**
-     * list-income / list-income YYYY-MM:
+     * list-income / list-income d/YYYY-MM:
      * - valid month
      * - empty
      * - invalid month
@@ -743,7 +760,7 @@ public class ParserTest {
     @Test
     public void parseOptionalMonthForIncomeList_cases() {
         // Valid
-        Optional<YearMonth> ok = Parser.parseOptionalMonthForIncomeList(Ui.LIST_INCOME_COMMAND + " 2030-07");
+        Optional<YearMonth> ok = Parser.parseOptionalMonthForIncomeList(Ui.LIST_INCOME_COMMAND + " d/2030-07");
         assertEquals(YearMonth.of(2030, 7), ok.get());
 
         // Empty -> Optional.empty()
@@ -751,12 +768,20 @@ public class ParserTest {
         assertTrue(none.isEmpty());
 
         // Invalid
-        String bad = Ui.LIST_INCOME_COMMAND + " 2030-7"; // not zero-padded month
+        String bad = Ui.LIST_INCOME_COMMAND + " d/2030-7"; // not zero-padded month
         try {
             Parser.parseOptionalMonthForIncomeList(bad);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("Month must be in YYYY-MM format.", e.getMessage());
+        }
+
+        // Missing prefix
+        try {
+            Parser.parseOptionalMonthForIncomeList(Ui.LIST_INCOME_COMMAND + " 2030-07");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals("Usage: list-income [d/YYYY-MM]", e.getMessage());
         }
     }
 }

--- a/src/test/java/seedu/fintrack/UiTest.java
+++ b/src/test/java/seedu/fintrack/UiTest.java
@@ -87,7 +87,7 @@ public class UiTest {
         assertEquals("delete-expense", Ui.DELETE_EXPENSE_COMMAND);
         assertEquals("delete-income", Ui.DELETE_INCOME_COMMAND);
         assertEquals("balance", Ui.BALANCE_COMMAND);
-        assertEquals("list", Ui.LIST_COMMAND);
+        assertEquals("list-expense", Ui.LIST_EXPENSE_COMMAND);
         assertEquals("bye", Ui.EXIT_COMMAND);
     }
 
@@ -320,7 +320,7 @@ public class UiTest {
         assertTrue(s.contains(Ui.ADD_EXPENSE_COMMAND));
         assertTrue(s.contains(Ui.ADD_INCOME_COMMAND));
         assertTrue(s.contains(Ui.DELETE_EXPENSE_COMMAND));
-        assertTrue(s.contains(Ui.LIST_COMMAND));
+        assertTrue(s.contains(Ui.LIST_EXPENSE_COMMAND));
         assertTrue(s.contains(Ui.BALANCE_COMMAND));
         assertTrue(s.contains(Ui.EXIT_COMMAND));
     }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -471,28 +471,28 @@ Description: Monthly salary
    Available categories: SALARY, SCHOLARSHIP, INVESTMENT, GIFT
 
 3. View all expenses (from latest to earliest date):
-   list
-   To view by month: list <YYYY-MM>
-   Example: list 2025-10
+   list-expense
+   To view by month: list-expense d/<YYYY-MM>
+   Example: list-expense d/2025-10
 
 4. View all incomes (from latest to earliest date):
    list-income
-   To view by month: list-income <YYYY-MM>
-   Example: list-income 2025-10
+   To view by month: list-income d/<YYYY-MM>
+   Example: list-income d/2025-10
 
 5. Delete an expense:
    delete-expense <index>
-   Deletes the expense shown at that index in 'list'.
+   Deletes the expense shown at that index in 'list-expense'.
    Example: delete-expense 1
 
 6. Delete an income:
    delete-income <index>
-   Deletes the income shown at that index in 'list'.
+   Deletes the income shown at that index in 'list-income'.
    Example: delete-income 1
 
 7. Modify an expense:
    modify-expense <index> a/<amount> c/<category> d/<YYYY-MM-DD> [desc/<description>]
-   Modifies the expense shown at that index in 'list'.
+   Modifies the expense shown at that index in 'list-expense'.
    Example: modify-expense 1 a/1300 c/Rent d/2024-01-01 desc/Monthly rent increased
 
 8. Modify an income:
@@ -503,8 +503,8 @@ Description: Monthly salary
 9. View balance summary:
    balance
    Shows total income, total expenses, and current balance.
-   To view by month: balance <YYYY-MM>
-   Example: balance 2025-10
+   To view by month: balance d/<YYYY-MM>
+   Example: balance d/2025-10
 
 10. Set budget for expense categories:
     budget

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -14,35 +14,35 @@ add-expense a/1400 c/Rent d/2024-03-01 desc/Monthly rent payment
 add-expense a/55 c/Food d/2024-03-03
 add-expense a/20 c/Transport d/2024-03-05 desc/Taxi
 balance
-list
+list-expense
 list-income
-balance 2024-01
-list 2024-01
-list-income 2024-01
-balance 2024-02
-list 2024-02
-list-income 2024-02
-balance 2024-03
-list 2024-03
-list-income 2024-03
-balance 2024-04
-list 2024-04
-list-income 2024-04
-balance 24-01
-list 2024/01
-list-income 202401
+balance d/2024-01
+list-expense d/2024-01
+list-income d/2024-01
+balance d/2024-02
+list-expense d/2024-02
+list-income d/2024-02
+balance d/2024-03
+list-expense d/2024-03
+list-income d/2024-03
+balance d/2024-04
+list-expense d/2024-04
+list-income d/2024-04
+balance d/24-01
+list-expense d/2024/01
+list-income d/202401
 modify-expense 9 a/1300 c/Rent d/2024-01-01 desc/Monthly rent increased
-list
+list-expense
 modify-expense 8 a/45 c/Food d/2024-01-02 desc/Updated food cost
-list
+list-expense
 modify-income 4 a/250 c/Salary d/2024-01-15 desc/Extra performance bonus
 list-income
 balance
 delete-expense 1
 delete-income 2
 balance
-balance 2024-03
-list 2024-03
-list-income 2024-03
+balance d/2024-03
+list-expense d/2024-03
+list-income d/2024-03
 help
 bye


### PR DESCRIPTION
  - rename the expense listing command from `list` to `list-expense`, updating the dispatcher, help output, and UI tests                                                                                     
  - require `balance`, `list-expense`, and `list-income` to accept monthly filters only via the `d/` prefix, adding targeted error messages for missing prefixes or extra arguments                              
  - refresh parser unit coverage plus the text-UI integration script/expected output to match the new syntax 

Fixes #79  